### PR TITLE
Fix NET Typo

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -71,7 +71,7 @@
 				KJV 2000 (King James Version 2000) (Offline)
 			</option>
 			<option>
-				KJV (King James Version) (Online)
+				NET (New English Translation) (Online)
 			</option>
 		</select>
 		<br><hr>


### PR DESCRIPTION
I believe that "NET" was what was meant when it reads KJV Online. @pufflegamerz 